### PR TITLE
Update ABB references to B&R in cybersecurity advisory

### DIFF
--- a/csaf_files/OT/white/2026/icsa-26-125-04.json
+++ b/csaf_files/OT/white/2026/icsa-26-125-04.json
@@ -2,7 +2,7 @@
   "document": {
     "acknowledgments": [
       {
-        "organization": "ABB PSIRT",
+        "organization": "B&R PSIRT",
         "summary": "reported this vulnerability to CISA."
       }
     ],
@@ -19,12 +19,12 @@
     "notes": [
       {
         "category": "summary",
-        "text": "ABB became aware of vulnerability in the product versions listed as affected in the advisory. An update is available that resolves a vulnerability.\n\nSuccessful exploitation of this vulnerability may enable an attacker to masquerade as a trusted party when B&R Automation Studio establishes a connection with a server via the ANSL over TLS or OPC-UA protocol.",
+        "text": "B&R became aware of vulnerability in the product versions listed as affected in the advisory. An update is available that resolves a vulnerability.\n\nSuccessful exploitation of this vulnerability may enable an attacker to masquerade as a trusted party when B&R Automation Studio establishes a connection with a server via the ANSL over TLS or OPC-UA protocol.",
         "title": "Summary"
       },
       {
         "category": "other",
-        "text": "For any installation of software related ABB products we strongly recommend the following (non-exhaustive) list of cyber security practices:\n\n\u2013 Isolate special purpose networks (e.g. for automation systems) and remote devices behind firewalls\nand separate them from any general-purpose network (e.g. office or home networks).\n\n\u2013 Install physical controls so no unauthorized personnel can access your devices, components, peripheral equipment, and networks.\n\n\u2013 Never connect programming software or computers containing programing software to any network other than the network for the devices that it is intended for.\n\n\u2013 Scan all data imported into your environment before use to detect potential malware infections.\n\n\u2013 Minimize network exposure for all applications and endpoints to ensure that they are not accessible\nfrom the Internet unless they are designed for such exposure and the intended use requires such.\n\n\u2013 Ensure all nodes are always up to date in terms of installed software, operating system, and firmware\npatches as well as anti-virus and firewall.\n\n\u2013 When remote access is required, use secure methods, such as Virtual Private Networks (VPNs). Recognize that VPNs may have vulnerabilities and should be updated to the most current version available. Also, understand that VPNs are only as secure as the connected devices.\n\nMore information on recommended practices can be found in the following documents:\n- Defense in Depth for B&R products : https://www.br-automation.com/fileadmin/Cyber_Security_-_Defense_in_Depth_for_BR_Products-bdd37e82.pdf\n",
+        "text": "For any installation of software related B&R products we strongly recommend the following (non-exhaustive) list of cyber security practices:\n\n\u2013 Isolate special purpose networks (e.g. for automation systems) and remote devices behind firewalls\nand separate them from any general-purpose network (e.g. office or home networks).\n\n\u2013 Install physical controls so no unauthorized personnel can access your devices, components, peripheral equipment, and networks.\n\n\u2013 Never connect programming software or computers containing programing software to any network other than the network for the devices that it is intended for.\n\n\u2013 Scan all data imported into your environment before use to detect potential malware infections.\n\n\u2013 Minimize network exposure for all applications and endpoints to ensure that they are not accessible\nfrom the Internet unless they are designed for such exposure and the intended use requires such.\n\n\u2013 Ensure all nodes are always up to date in terms of installed software, operating system, and firmware\npatches as well as anti-virus and firewall.\n\n\u2013 When remote access is required, use secure methods, such as Virtual Private Networks (VPNs). Recognize that VPNs may have vulnerabilities and should be updated to the most current version available. Also, understand that VPNs are only as secure as the connected devices.\n\nMore information on recommended practices can be found in the following documents:\n- Defense in Depth for B&R products : https://www.br-automation.com/fileadmin/Cyber_Security_-_Defense_in_Depth_for_BR_Products-bdd37e82.pdf\n",
         "title": "General security recommendations"
       },
       {
@@ -34,7 +34,7 @@
       },
       {
         "category": "other",
-        "text": "For additional instructions and support please contact your local B&R service organization. For contact information, see https://www.br-automation.com/en/about-us/locations/.\n\nInformation about ABB\u2019s cyber security program and capabilities can be found at www.abb.com/cybersecurity.\n",
+        "text": "For additional instructions and support please contact your local B&R service organization. For contact information, see https://www.br-automation.com/en/about-us/locations/.\n\nInformation about B&R\u2019s cyber security program and capabilities can be found at www.abb.com/cybersecurity.\n",
         "title": "Support"
       },
       {
@@ -54,7 +54,7 @@
       },
       {
         "category": "other",
-        "text": "This ICSA is a verbatim republication of ABB PSIRT SA25P004 from a direct conversion of the vendor's Common Security Advisory Framework (CSAF) advisory. This is republished to CISA's website as a means of increasing visibility and is provided \"as-is\" for informational purposes only. CISA is not responsible for the editorial or technical accuracy of republished advisories and provides no warranties of any kind regarding any information contained within this advisory.  Further, CISA does not endorse any commercial product or service.  Please contact ABB PSIRT directly for any questions regarding this advisory.",
+        "text": "This ICSA is a verbatim republication of B&R PSIRT SA25P004 from a direct conversion of the vendor's Common Security Advisory Framework (CSAF) advisory. This is republished to CISA's website as a means of increasing visibility and is provided \"as-is\" for informational purposes only. CISA is not responsible for the editorial or technical accuracy of republished advisories and provides no warranties of any kind regarding any information contained within this advisory.  Further, CISA does not endorse any commercial product or service.  Please contact B&R PSIRT directly for any questions regarding this advisory.",
         "title": "Advisory Conversion Disclaimer"
       },
       {
@@ -127,7 +127,7 @@
       },
       {
         "category": "self",
-        "summary": "ABB CYBERSECURITY ADVISORY - PDF version ",
+        "summary": "B&R CYBERSECURITY ADVISORY - PDF version ",
         "url": "https://www.br-automation.com/fileadmin/SA25P004-4f45197f.pdf"
       },
       {
@@ -171,7 +171,7 @@
         "url": "https://www.cisa.gov/news-events/news/targeted-cyber-intrusion-detection-and-mitigation-strategies-update-b"
       }
     ],
-    "title": "ABB B&R Automation Studio",
+    "title": "B&R Automation Studio",
     "tracking": {
       "current_release_date": "2026-05-05T06:00:00.000000Z",
       "generator": {
@@ -194,7 +194,7 @@
           "date": "2026-05-05T06:00:00.000000Z",
           "legacy_version": "CISA Republication",
           "number": "2",
-          "summary": "Initial CISA Republication of ABB PSIRT SA25P004 advisory"
+          "summary": "Initial CISA Republication of B&R PSIRT SA25P004 advisory"
         }
       ],
       "status": "final",
@@ -211,7 +211,7 @@
                 "category": "product_version_range",
                 "name": "<6.5",
                 "product": {
-                  "name": "ABB Automation Studio <6.5",
+                  "name": "B&R Automation Studio <6.5",
                   "product_id": "CSAFPID-0001"
                 }
               },
@@ -219,7 +219,7 @@
                 "category": "product_version",
                 "name": "6.5",
                 "product": {
-                  "name": "ABB Automation Studio 6.5",
+                  "name": "B&R Automation Studio 6.5",
                   "product_id": "CSAFPID-0002"
                 }
               }
@@ -229,7 +229,7 @@
           }
         ],
         "category": "vendor",
-        "name": "ABB"
+        "name": "B&R Industrial Automation GmbH"
       }
     ]
   },
@@ -287,7 +287,7 @@
         },
         {
           "category": "mitigation",
-          "details": "To exploit this vulnerability, an attacker would need to intercept and redirect the communication between B&R Automation Studio and the target server, as well as present manipulated certificates that pass validation checks. B&R recommends operating B&R Automation Studio within Level 2 of the ABB ICS Cyber Security Reference Architecture when connecting to Level 1 devices via ANSL over TLS or OPC-UA. Operating in this trusted environment reduces the risk of successful exploitation drastically.\n\nRefer to section \u201cGeneral security recommendations\u201d for further advise on how to keep your system secure.\n",
+          "details": "To exploit this vulnerability, an attacker would need to intercept and redirect the communication between B&R Automation Studio and the target server, as well as present manipulated certificates that pass validation checks. B&R recommends operating B&R Automation Studio within Level 2 of the B&R ICS Cyber Security Reference Architecture when connecting to Level 1 devices via ANSL over TLS or OPC-UA. Operating in this trusted environment reduces the risk of successful exploitation drastically.\n\nRefer to section \u201cGeneral security recommendations\u201d for further advise on how to keep your system secure.\n",
           "product_ids": [
             "CSAFPID-0001"
           ]


### PR DESCRIPTION
B&R Industrial Automation GmbH is the correct vendor for the B&R product identified within this advisory. B&R is one of many member companies under the ABB Group. The ABB CSAF JSON incorrectly identify this affected product as ABB when it is identified as a B&R product in the original advisory released on January 19th, 2026: https://www.br-automation.com/fileadmin/SA25P004-4f45197f.pdf

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
The Vendor and Product,. This is an advisory for B&R Industrial Automation GmbH not ABB. B&R Industrial Automation GmbH is a company under ABB.
<!-- To avoid scope creep, limit changes to a single goal. -->
Correctly identify the vendor and product according to the original security notification released in January 2026.

## 💭 Motivation and context ##
Accuracy of vendor and product names. Historically, CISA as identify B&R products as B&R Industrial Automation GmbH, not ABB.
<!-- Why is this change required? -->
For asset owner to accurately identify affected products by this reported vulnerability.

<!-- What problem does this change solve? How did you solve it? -->
Improves the accuracy and consistency of this advisory.

<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
