### PR TITLE
Fix ICSMA-26-216-01 JSON syntax

### DIFF
--- a/csaf_files/OT/white/2026/icsma-26-216-01.json
+++ b/csaf_files/OT/white/2026/icsma-26-216-01.json
@@ -5,7 +5,7 @@
         "names": [
           "Nathaniel Adams",
           "Laura Gaydosh-Combs",
-          "Kevin Dyer",
+          "Kevin Dyer"
         ],
         "summary": "discovered this vulnerability"
       }


### PR DESCRIPTION
Removes the trailing comma from the acknowledgments names array in ICSMA-26-216-01 so the CSAF document is valid strict JSON again.

Validation performed:
- JSON.parse succeeds
- tracking ID remains ICSMA-26-216-01
- vulnerabilities array remains present with one entry
- the diff changes only the invalid trailing comma